### PR TITLE
Fix broken URL in /enterprise/superadmin #6305

### DIFF
--- a/docs/docs/Enterprise/superadmin.md
+++ b/docs/docs/Enterprise/superadmin.md
@@ -17,7 +17,7 @@ The user details entered while setting up ToolJet will have Super Admin privileg
 | Manage Groups in their workspace (Create Group/Add or Delete Users from groups/ Modify Group Permissions) | ✅ | ✅ |
 | Manage SSO in their workspace | ✅ | ✅ |
 | Manage Workspace Variables in their workspace | ✅ | ✅ |
-| [Manage Global datasources for the user group in their workspace](/docs/next/data-sources/overview#permissions) | ✅ | ✅ |
+| [Manage Global datasources for the user group in their workspace](https://docs.tooljet.com/docs/data-sources/overview#permissions) | ✅ | ✅ |
 | [Access any user's personal workspace (create, edit or delete apps)](#access-any-workspace) | ❌ | ✅ |
 | [Archive Admin or any user of any workspace](#archiveunarchive-users) | ❌ | ✅ |
 | [Access any user's ToolJet database (create, edit or delete database)](#access-tooljet-db-in-any-workspace) | ❌ | ✅ |


### PR DESCRIPTION
The hyperlink of the text Manage Global datasources for the user group in their workspace in the section "How is Super Admin different from Admin" was broken ,it has been replaced with correct (new) link